### PR TITLE
update resource values

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -26,13 +26,10 @@ components:
   - name: outerloop-deploy
     attributes:
       deployment/replicas: 1
-      deployment/route: route1
-      deployment/storageLimit: 400Mi
-      deployment/storageRequest: 200Mi
-      deployment/cpuLimit: "2"
-      deployment/cpuRequest: 700m
-      deployment/memoryLimit: 500Mi
-      deployment/memoryRequest: 400Mi
+      deployment/cpuLimit: "100m"
+      deployment/cpuRequest: 10m
+      deployment/memoryLimit: 250Mi
+      deployment/memoryRequest: 100Mi
       deployment/container-port: 8081
     kubernetes:
       uri: outerloop-deploy.yaml


### PR DESCRIPTION

Signed-off-by: Stephanie <yangcao@redhat.com>

For DEVHAS-125
quarkus uses 
```
NAME                               CPU(cores)   MEMORY(bytes)  
java-quarkus-84d8f8cc4d-fzf4l   1m           80Mi 
```
update the resource value to 
```
deployment/cpuLimit: "100m"
deployment/cpuRequest: 10m
deployment/memoryLimit: 250Mi
deployment/memoryRequest: 100Mi
```