### PR TITLE
Update to Java 17 and mvn build img

### DIFF
--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -19,6 +19,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/openjdk-17:1.14-10.1675788279
 
+USER root
 WORKDIR /build
 
 COPY pom.xml .

--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -27,6 +27,13 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package -Dmaven.test.skip=true
 
+RUN mkdir -p /build/target/quarkus-app-tmp
+RUN grep version /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-version 
+RUN grep artifactId /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-id
+
+# mv the uber jar in case the quarkus property quarkus.package.type=uber-jar is set
+RUN mv /build/target/$(cat .env-id)-$(cat .env-version)*.jar /build/target/quarkus-app-tmp/
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085 
 
 ARG JAVA_PACKAGE=java-17-openjdk-devel
@@ -49,10 +56,12 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8081 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=0 --chown=1001 /build/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=0 --chown=1001 /build/target/quarkus-app/*.jar /deployments/
-COPY --from=0 --chown=1001 /build/target/quarkus-app/app/ /deployments/app/
-COPY --from=0 --chown=1001 /build/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=0 --chown=1001 /build/target/quarkus-app-tmp/*.jar /deployments/export-run-artifact.jar
+COPY --from=0 --chown=1001 /build/target/*quarkus-app/*lib/ /deployments/lib/
+# Overwrite the uber jar if package type is normal
+COPY --from=0 --chown=1001 /build/target/*quarkus-app/*.jar /deployments/export-run-artifact.jar 
+COPY --from=0 --chown=1001 /build/target/*quarkus-app/*app/ /deployments/app/
+COPY --from=0 --chown=1001 /build/target/*quarkus-app/*quarkus/ /deployments/quarkus/
 
 EXPOSE 8081
 USER 1001

--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -17,23 +17,19 @@
 # docker run -i --rm -p 8081:8081 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.14-10.1675788279
 
-USER root
 WORKDIR /build
-RUN mkdir -p .mvn/wrapper
-# Build dependency offline to streamline build
-COPY mvnw* .
-COPY .mvn/wrapper .mvn/wrapper
+
 COPY pom.xml .
-RUN ./mvnw dependency:go-offline
+RUN mvn dependency:go-offline
 
 COPY src src
-RUN ./mvnw package
+RUN mvn package -Dmaven.test.skip=true
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-devel
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script


### PR DESCRIPTION
This PR updates 

- the runtime image to include Java 17
- the build image to include mvn so we dont rely on a mvn wrapper
- generalizes so as to be able to handle an uber jar when `quarkus.package.type=uber-jar` is set