### PR TITLE
add file to enable buildah to work

### DIFF
--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -34,7 +34,7 @@ RUN grep artifactId /build/target/maven-archiver/pom.properties | cut -d '=' -f2
 
 # mv the uber jar in case the quarkus property quarkus.package.type=uber-jar is set
 RUN mv /build/target/$(cat .env-id)-$(cat .env-version)*.jar /build/target/quarkus-app-tmp/
-
+RUN echo "copyhack" > /build/target/copyhack 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085 
 
 ARG JAVA_PACKAGE=java-17-openjdk-devel
@@ -57,12 +57,12 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8081 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=0 --chown=1001 /build/target/quarkus-app-tmp/*.jar /deployments/export-run-artifact.jar
-COPY --from=0 --chown=1001 /build/target/*quarkus-app/*lib/ /deployments/lib/
+COPY --from=0 --chown=1001 /build/target/copyhack /build/target/quarkus-app-tmp/*.jar /deployments/export-run-artifact.jar
+COPY --from=0 --chown=1001 /build/target/copyhack /build/target/*quarkus-app/*lib/ /deployments/lib/
 # Overwrite the uber jar if package type is normal
-COPY --from=0 --chown=1001 /build/target/*quarkus-app/*.jar /deployments/export-run-artifact.jar 
-COPY --from=0 --chown=1001 /build/target/*quarkus-app/*app/ /deployments/app/
-COPY --from=0 --chown=1001 /build/target/*quarkus-app/*quarkus/ /deployments/quarkus/
+COPY --from=0 --chown=1001 /build/target/copyhack /build/target/*quarkus-app/*.jar /deployments/export-run-artifact.jar 
+COPY --from=0 --chown=1001 /build/target/copyhack /build/target/*quarkus-app/*app/ /deployments/app/
+COPY --from=0 --chown=1001 /build/target/copyhack /build/target/*quarkus-app/*quarkus/ /deployments/quarkus/
 
 EXPOSE 8081
 USER 1001


### PR DESCRIPTION
This change adds an extra file to the COPY to workaround an issue in buildah.
This ensures the dockerfile works with fast-jar and uber-jars for Quarkus.
Issue: 
When buildah sees an empty COPY, it fails. Docker does not. Adding a file to the copy fixes the issue.
The empty COPY comes from the fact that this Dockerfile attempts to work for fast-jars and uber-jars. In Uber jar mode, some of the directories don't exist or are empty. Adding an extra file to the copy fixes the issue. 

To test build use the demo https://github.com/jduimovich/code-with-quarkus
and test the branches `fast-jar` and `uber-jar`  which only differ in one file.
The test can be found at [ https://github.com/jduimovich/test-remote ](https://github.com/jduimovich/test-remote), can be run after installing pipelines in build-definitions.

 