### PR TITLE
Update port from 8081 to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Creating an application with a Quarkus code sample
 
-**Note:** The Quarkus code sample uses the **8081** HTTP port.
+**Note:** The Quarkus code sample uses the **8080** HTTP port.
 
 Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           image: java-quarkus-image:latest
           ports:
             - name: http
-              containerPort: 8081
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:
@@ -30,9 +30,9 @@ metadata:
   name: my-java-quarkus-svc
 spec:
 ports:
-  - name: http-8081
-    port: 8081
+  - name: http-8080
+    port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
 selector:
   app: java-quarkus-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,12 +31,12 @@ components:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 100Mi
-      deployment/container-port: 8081
+      deployment/container-port: 8080
     kubernetes:
       uri: deploy.yaml
       endpoints:
-        - name: http-8081
-          targetPort: 8081
+        - name: http-8080
+          targetPort: 8080
           path: /
 commands:
   - id: build-image

--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -7,14 +7,14 @@
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8081:8081 quarkus/code-with-quarkus-jvm
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8081:8081 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/openjdk-17:1.15-1.1682053058
@@ -41,12 +41,12 @@ RUN if [ ! -d /build/target/quarkus-app ] ; then mkdir -p /build/target/quarkus-
 
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15-1.1682053056
 # Configure the JAVA_OPTS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8081 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8080 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --from=0 --chown=1001 /build/target/quarkus-app/lib/ /deployments/lib/
 COPY --from=0 --chown=1001 /build/target/quarkus-app/*.jar /deployments/export-run-artifact.jar
 COPY --from=0 --chown=1001 /build/target/quarkus-app/app/ /deployments/app/
 COPY --from=0 --chown=1001 /build/target/quarkus-app/quarkus/ /deployments/quarkus/
-EXPOSE 8081
+EXPOSE 8080
 ENTRYPOINT ["/opt/jboss/container/java/run/run-java.sh"]
 


### PR DESCRIPTION
- Updates the devfile sample port from 8081 to 8080
- Doesnt update the attribute `alpha.dockerimage-port: 8081` because of backward compatibility in ODC earlier versions. We dont want to backport devfile/library update that far back. 